### PR TITLE
Test suite updated for Elixir 1.3

### DIFF
--- a/lib/json_api_assert.ex
+++ b/lib/json_api_assert.ex
@@ -37,11 +37,12 @@ defmodule JsonApiAssert do
   def assert_jsonapi(%{"jsonapi" => jsonapi} = payload, members) do
     Enum.reduce(members, [], fn({key, value}, unmatched) ->
       actual_value = jsonapi[Atom.to_string(key)]
-      if actual_value != value do
-        unmatched = unmatched ++ ["Expected:\n  `#{key}` \"#{value}\"\nGot:\n  `#{key}` \"#{actual_value}\""]
-      end
 
-      unmatched
+      if actual_value != value do
+        unmatched ++ ["Expected:\n  `#{key}` \"#{value}\"\nGot:\n  `#{key}` \"#{actual_value}\""]
+      else
+        unmatched
+      end
     end)
     |> case do
       [] -> payload

--- a/lib/json_api_assert/error.ex
+++ b/lib/json_api_assert/error.ex
@@ -1,0 +1,3 @@
+defmodule JsonApiAssert.Error do
+  defexception [:message]
+end

--- a/test/assert_data_test.exs
+++ b/test/assert_data_test.exs
@@ -37,16 +37,22 @@ defmodule AssertDataTest do
       data(:post)
       |> put_in(["id"], 2)
 
-    assert_raise ExUnit.AssertionError, msg, fn ->
+    try do
       assert_data(data(:payload), post)
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
     end
   end
 
   test "will raise when there is a type mismatch" do
     msg = "could not find a record with matching `id` 1 and `type` \"article\""
 
-    assert_raise ExUnit.AssertionError, msg, fn ->
+    try do
       assert_data(data(:payload), @article)
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
     end
   end
 

--- a/test/assert_included_test.exs
+++ b/test/assert_included_test.exs
@@ -38,16 +38,22 @@ defmodule AssertIncludedTest do
       data(:author)
       |> put_in(["id"], 2)
 
-    assert_raise ExUnit.AssertionError, msg, fn ->
+    try do
       assert_included(data(:payload), author)
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
     end
   end
 
   test "will raise when there is a type mismatch" do
     msg = "could not find a record with matching `id` 1 and `type` \"writer\""
 
-    assert_raise ExUnit.AssertionError, msg, fn ->
+    try do
       assert_included(data(:payload), @writer)
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
     end
   end
 

--- a/test/assert_relationship_test.exs
+++ b/test/assert_relationship_test.exs
@@ -8,14 +8,20 @@ defmodule AssertRelationshipTest do
   end
 
   test "will raise if `as:` is not passed" do
-    assert_raise ExUnit.AssertionError, "you must pass `as:` with the name of the relationship", fn ->
+    try do
       assert_relationship(data(:payload), data(:author), for: data(:post))
+    rescue
+      error in [ExUnit.AssertionError] ->
+      assert "you must pass `as:` with the name of the relationship" == error.message
     end
   end
 
   test "will raise if `for:` is not passed" do
-    assert_raise ExUnit.AssertionError, "you must pass `for:` with the parent record", fn ->
+    try do
       assert_relationship(data(:payload), data(:author), as: "author")
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert "you must pass `for:` with the parent record" == error.message
     end
   end
 
@@ -25,8 +31,11 @@ defmodule AssertRelationshipTest do
       data(:author)
       |> put_in(["id"], 2)
 
-    assert_raise ExUnit.AssertionError, msg, fn ->
+    try do
       assert_relationship(data(:payload), author, as: "author", for: data(:post))
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
     end
   end
 
@@ -36,16 +45,22 @@ defmodule AssertRelationshipTest do
       data(:author)
       |> put_in(["type"], "writer")
 
-    assert_raise ExUnit.AssertionError, msg, fn ->
+    try do
       assert_relationship(data(:payload), author, as: "author", for: data(:post))
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
     end
   end
 
   test "will raise when relationship name not found" do
     msg = "could not find the relationship `writer` for record matching `id` 1 and `type` \"post\""
 
-    assert_raise ExUnit.AssertionError, msg, fn ->
+    try do
       assert_relationship(data(:payload), data(:author), as: "writer", for: data(:post))
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
     end
   end
 
@@ -62,8 +77,11 @@ defmodule AssertRelationshipTest do
       }
     }
 
-    assert_raise ExUnit.AssertionError, msg, fn ->
+    try do
       assert_relationship(payload, data(:author), as: "writer", for: data(:post))
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
     end
   end
 

--- a/test/jsonapi_test.exs
+++ b/test/jsonapi_test.exs
@@ -13,8 +13,11 @@ defmodule AssertJsonApiTest do
   end
 
   test "assert - will raise if no jsonapi object exists" do
-    assert_raise ExUnit.AssertionError, "jsonapi object not found", fn ->
+    try do
       assert_jsonapi(%{}, version: "1.1")
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert "jsonapi object not found" == error.message
     end
   end
 
@@ -25,8 +28,11 @@ defmodule AssertJsonApiTest do
       }
     }
 
-    assert_raise ExUnit.AssertionError, "jsonapi object mismatch\nExpected:\n  `version` \"1.1\"\nGot:\n  `version` \"1.0\"", fn ->
+    try do
       assert_jsonapi(payload, version: "1.1")
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert "jsonapi object mismatch\nExpected:\n  `version` \"1.1\"\nGot:\n  `version` \"1.0\"" == error.message
     end
   end
 

--- a/test/refute_data_test.exs
+++ b/test/refute_data_test.exs
@@ -19,8 +19,11 @@ defmodule RefuteDataTest do
 
     msg = "did not expect #{inspect record} to be found."
 
-    assert_raise ExUnit.AssertionError, msg, fn ->
+    try do
       refute_data(data(:payload), data(:post))
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
     end
   end
 

--- a/test/refute_included_test.exs
+++ b/test/refute_included_test.exs
@@ -20,8 +20,11 @@ defmodule RefuteIncludedTest do
 
     msg = "did not expect #{inspect record} to be found."
 
-    assert_raise ExUnit.AssertionError, msg, fn ->
+    try do
       refute_included(data(:payload), data(:author))
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
     end
   end
 

--- a/test/refute_relationship_test.exs
+++ b/test/refute_relationship_test.exs
@@ -5,20 +5,30 @@ defmodule RefuteRelationshipTest do
 
   test "will raise when relationship is found in a data record" do
     msg = "was not expecting to find the relationship `author` with `id` 1 and `type` \"author\" for record matching `id` 1 and `type` \"post\""
-    assert_raise ExUnit.AssertionError, msg, fn ->
+
+    try do
       refute_relationship(data(:payload), data(:author), as: "author", for: data(:post))
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
     end
   end
 
   test "will raise if `as:` is not passed" do
-    assert_raise ExUnit.AssertionError, "you must pass `as:` with the name of the relationship", fn ->
+    try do
       refute_relationship(data(:payload), data(:author), for: data(:post))
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert "you must pass `as:` with the name of the relationship" == error.message
     end
   end
 
   test "will raise if `for:` is not passed" do
-    assert_raise ExUnit.AssertionError, "you must pass `for:` with the parent record", fn ->
+    try do
       refute_relationship(data(:payload), data(:author), as: "author")
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert "you must pass `for:` with the parent record" == error.message
     end
   end
 


### PR DESCRIPTION
ExUnit 1.3 introduces some padding for `ExUnit.AssertionError` message rendering. This updates test suite for Elixir 1.3
