### PR TITLE
Enforce top-level member specs

### DIFF
--- a/lib/json_api_assert.ex
+++ b/lib/json_api_assert.ex
@@ -35,6 +35,8 @@ defmodule JsonApiAssert do
   def assert_jsonapi(payload, members \\ [])
 
   def assert_jsonapi(%{"jsonapi" => jsonapi} = payload, members) do
+    enforce_top_level_constraints(payload)
+
     Enum.reduce(members, [], fn({key, value}, unmatched) ->
       actual_value = jsonapi[Atom.to_string(key)]
 
@@ -231,4 +233,15 @@ defmodule JsonApiAssert do
     do: payload ++ data
   defp merge_data(payload, data) when is_map(data),
     do: merge_data(payload, [data])
+
+  defp enforce_top_level_constraints(payload) do
+    if Map.has_key?(payload, "data") && Map.has_key?(payload, "errors"),
+      do: raise ExUnit.AssertionError, "the members `data` and `errors` MUST NOT coexist in the same document"
+
+    if !Map.has_key?(payload, "data") && Map.has_key?(payload, "included"),
+      do: raise ExUnit.AssertionError, "If a document does not contain a top-level data key, the included member MUST NOT be present either."
+
+    unless Map.has_key?(payload, "data") || Map.has_key?(payload, "errors") || Map.has_key?(payload, "meta"),
+      do: raise ExUnit.AssertionError, "A document MUST contain at least one of the following top-level members: 'data', 'errors', 'meta'"
+  end
 end

--- a/test/jsonapi_test.exs
+++ b/test/jsonapi_test.exs
@@ -1,11 +1,17 @@
 defmodule AssertJsonApiTest do
   use ExUnit.Case
   import JsonApiAssert, only: [assert_jsonapi: 2]
+  import JsonApiAssert.TestData, only: [data: 1]
 
-  test "assert - will not rise when matching jsonapi object exists" do
+  test "assert - will not raise when matching jsonapi object exists" do
     payload = %{
       "jsonapi" => %{
         "version" => "1.0"
+      },
+      "meta" => %{
+        "authors" => [
+          "Brian Cardarella"
+        ]
       }
     }
 
@@ -25,6 +31,11 @@ defmodule AssertJsonApiTest do
     payload = %{
       "jsonapi" => %{
         "version" => "1.0"
+      },
+      "meta" => %{
+        "authors" => [
+          "Brian Cardarella"
+        ]
       }
     }
 
@@ -36,13 +47,56 @@ defmodule AssertJsonApiTest do
     end
   end
 
-  test "assert will return original paylod" do
+  test "assert will return original payload" do
     payload = %{
       "jsonapi" => %{
         "version" => "1.0"
+      },
+      "meta" => %{
+        "authors" => [
+          "Brian Cardarella"
+        ]
       }
     }
 
     assert payload == assert_jsonapi(payload, version: "1.0")
+  end
+
+  test "will raise when both errors and data objects exist in the response" do
+    msg = "the members `data` and `errors` MUST NOT coexist in the same document"
+
+    assert_raise(ExUnit.AssertionError, msg, fn ->
+      Map.merge(data(:payload), %{"errors" => []})
+      |> assert_jsonapi(version: "1.0")
+    end)
+  end
+
+  test "will raise when an included object exists in the response without the presence of the data object" do
+    msg = "If a document does not contain a top-level data key, the included member MUST NOT be present either."
+
+    assert_raise(ExUnit.AssertionError, msg, fn ->
+      Map.delete(data(:payload), "data")
+      |> assert_jsonapi(version: "1.0")
+    end)
+  end
+
+  test "will raise if document does not contain at least one of the following objects: 'data', 'errors', 'meta'" do
+    msg = "A document MUST contain at least one of the following top-level members: 'data', 'errors', 'meta'"
+
+    assert_raise(ExUnit.AssertionError, msg, fn ->
+      Map.delete(data(:payload), "data")
+      |> Map.delete("included")
+      |> assert_jsonapi(version: "1.0")
+    end)
+
+    Map.delete(data(:payload), "data")
+    |> Map.delete("included")
+    |> Map.merge(%{"errors" => []})
+    |> assert_jsonapi(version: "1.0")
+
+    Map.delete(data(:payload), "data")
+    |> Map.delete("included")
+    |> Map.merge(%{"meta" => []})
+    |> assert_jsonapi(version: "1.0")
   end
 end


### PR DESCRIPTION
Work in progress.  The assert_jsonapi function seemed to be the best place for these checks.  Thoughts?  

Addresses #7 
