### PR TITLE
Implement assert_meta/2

### DIFF
--- a/lib/json_api_assert.ex
+++ b/lib/json_api_assert.ex
@@ -61,6 +61,37 @@ defmodule JsonApiAssert do
     do: raise ExUnit.AssertionError, "jsonapi object not found"
 
   @doc """
+  Asserts that a valid meta object exists in the payload
+
+  The members argument should be a map of key/value pairs that you expect to be
+  be in the "meta" object of the payload.
+
+  ## Examples
+
+    @meta %{
+      "license" => "The MIT License (MIT)",
+      "authors" => [
+        "Brian Cardarella"
+      ]
+    }
+
+    payload
+    |> assert_meta(@meta)
+  """
+  @spec assert_meta(map, map) :: map
+  def assert_meta(payload, members \\ %{})
+
+  def assert_meta(%{"meta" => meta}, _members) when not is_map(meta),
+    do: raise ExUnit.AssertionError, "the value of each meta member MUST be an object"
+  def assert_meta(%{"meta" => meta} = payload, members) do
+    ExUnit.Assertions.assert meta == members
+
+    payload
+  end
+  def assert_meta(_payload, _members),
+    do: raise ExUnit.AssertionError, "meta object not found"
+
+  @doc """
   Asserts that a given record is included in the `data` object of the payload.
 
   ## Examples

--- a/test/assert_meta_test.exs
+++ b/test/assert_meta_test.exs
@@ -1,0 +1,92 @@
+defmodule AssertMetaTest do
+  use ExUnit.Case
+  import JsonApiAssert, only: [assert_meta: 2, assert_meta: 1]
+  import JsonApiAssert.TestData, only: [data: 1]
+
+  test "assert will return original payload" do
+    result = Map.merge(data(:payload), data(:meta))
+    expected = assert_meta(Map.merge(data(:payload), data(:meta)), data(:meta)["meta"])
+
+    assert result == expected
+  end
+
+  test "assert will not raise when meta object is empty" do
+    Map.merge(data(:payload), %{"meta" => %{}})
+    |> assert_meta
+  end
+
+  test "assert will raise when meta is not found" do
+    msg = "meta object not found"
+
+    try do
+      assert_meta(data(:payload))
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
+    else
+      _ -> flunk """
+
+      Expected Exception
+
+      #{msg}
+
+      """
+    end
+  end
+
+  test "assert will raise when meta object is not a map" do
+    msg = "the value of each meta member MUST be an object"
+
+    try do
+      Map.merge(data(:payload), %{"meta" => []})
+      |> assert_meta
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
+    else
+      _ -> flunk """
+
+      Expected Exception
+
+      #{msg}
+
+      """
+    end
+
+    try do
+      Map.merge(data(:payload), %{"meta" => ""})
+      |> assert_meta
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
+    else
+      _ -> flunk """
+
+      Expected Exception
+
+      #{msg}
+
+      """
+    end
+  end
+
+  test "assert will raise when matching meta object does not exist" do
+    msg = "Assertion with == failed"
+
+    try do
+      Map.merge(data(:payload), data(:meta))
+      |> assert_meta(Map.merge(%{"copywrite" => "2016"}, data(:meta)["meta"]))
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
+    else
+      _ -> flunk """
+
+      Expected Exception
+
+      #{msg}
+
+      """
+    end
+  end
+end

--- a/test/support/test_data.ex
+++ b/test/support/test_data.ex
@@ -84,6 +84,17 @@ defmodule JsonApiAssert.TestData do
     }
   end
 
+  def meta do
+    %{
+      "meta" => %{
+        "license" => "The MIT License (MIT)",
+        "authors" => [
+          "Brian Cardarella"
+        ]
+      }
+    }
+  end
+
   def payload do
     %{
       "jsonapi" => %{


### PR DESCRIPTION
Add assertion `assert_meta/2` that validates the document's top-level meta
object and it's optional members.

Addresses meta #1 

I'm not certain how to address nested meta objects.  I'll happily adjust this to do so if needed. 👍 
