### PR TITLE
List assertions

### DIFF
--- a/lib/json_api_assert.ex
+++ b/lib/json_api_assert.ex
@@ -67,8 +67,15 @@ defmodule JsonApiAssert do
 
       payload
       |> assert_data(user1)
+
+  Can also take a list of records. The list will be iterated over asserting each record individually.
   """
-  @spec assert_data(map, map | struct) :: map
+  @spec assert_data(map, map | struct | list) :: map
+  def assert_data(payload, []), do: payload
+  def assert_data(payload, [record | records]) do
+    assert_data(payload, record)
+    |> assert_data(records)
+  end
   def assert_data(payload, record) do
     assert_record(payload["data"], record)
 
@@ -82,8 +89,15 @@ defmodule JsonApiAssert do
 
       payload
       |> refute_data(user1)
+
+  Can also take a list of records. The list will be iterated over refuting each record individually.
   """
-  @spec refute_data(map, map | struct) :: map
+  def refute_data(payload, []), do: payload
+  def refute_data(payload, [record | records]) do
+    refute_data(payload, record)
+    |> refute_data(records)
+  end
+  @spec refute_data(map, map | struct | list) :: map
   def refute_data(payload, record) do
     refute_record(payload["data"], record)
 
@@ -97,8 +111,15 @@ defmodule JsonApiAssert do
 
       payload
       |> assert_included(pet1)
+
+  Can also take a list of records. The list will be iterated over asserting each record individually.
   """
-  @spec assert_included(map, map | struct) :: map
+  @spec assert_included(map, map | struct | list) :: map
+  def assert_included(payload, []), do: payload
+  def assert_included(payload, [record | records]) do
+    assert_included(payload, record)
+    |> assert_included(records)
+  end
   def assert_included(payload, record) do
     assert_record(payload["included"], record)
 
@@ -113,8 +134,15 @@ defmodule JsonApiAssert do
 
       payload
       |> refute_included(pet1)
+
+  Can also take a list of records. The list will be iterated over refuting each record individually.
   """
-  @spec refute_included(map, map | struct) :: map
+  @spec refute_included(map, map | struct | list) :: map
+  def refute_included(payload, []), do: payload
+  def refute_included(payload, [record | records]) do
+    refute_included(payload, record)
+    |> refute_included(records)
+  end
   def refute_included(payload, record) do
     refute_record(payload["included"], record)
 

--- a/test/assert_data_test.exs
+++ b/test/assert_data_test.exs
@@ -61,4 +61,21 @@ defmodule AssertDataTest do
 
     assert payload == data(:payload)
   end
+
+  test "can assert many records at once" do
+    payload = assert_data(data(:payload_2), [data(:post), data(:post_2)])
+
+    assert payload == data(:payload_2)
+  end
+
+  test "will fail if one of the records is not present" do
+    msg = "could not find a record with matching `id` 2 and `type` \"post\""
+
+    try do
+      assert_data(data(:payload), [data(:post), data(:post_2)])
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
+    end
+  end
 end

--- a/test/assert_included_test.exs
+++ b/test/assert_included_test.exs
@@ -62,4 +62,21 @@ defmodule AssertIncludedTest do
 
     assert payload == data(:payload)
   end
+
+  test "can assert many records at once" do
+    payload = assert_included(data(:payload_2), [data(:comment_1), data(:comment_2)])
+
+    assert payload == data(:payload_2)
+  end
+
+  test "will fail if one of the records is not present" do
+    msg = "could not find a record with matching `id` 3 and `type` \"comment\""
+
+    try do
+      assert_included(data(:payload), [data(:comment_1), data(:comment_3)])
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
+    end
+  end
 end

--- a/test/refute_data_test.exs
+++ b/test/refute_data_test.exs
@@ -44,4 +44,29 @@ defmodule RefuteDataTest do
 
     refute_data(data(:payload), post)
   end
+
+  test "can refute many records at once" do
+    post =
+      data(:post)
+      |> put_in(["attributes", "title"], "Father of all demos")
+
+    payload = refute_data(data(:payload), [post, data(:post_2)])
+
+    assert payload == data(:payload)
+  end
+
+  test "will fail if one of the records is present" do
+    record = %{
+      "id" => "1",
+      "type" => "post"
+    }
+    msg = "did not expect #{inspect record} to be found."
+
+    try do
+      refute_data(data(:payload), [data(:post_2), data(:post)])
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
+    end
+  end
 end

--- a/test/refute_included_test.exs
+++ b/test/refute_included_test.exs
@@ -46,4 +46,25 @@ defmodule RefuteIncludedTest do
 
     refute_included(data(:payload), author)
   end
+
+  test "can refute many records at once" do
+    payload = refute_included(data(:payload), [data(:comment_3), data(:comment_4)])
+
+    assert payload == data(:payload)
+  end
+
+  test "will fail if one of the records is present" do
+    record = %{
+      "id" => "1",
+      "type" => "comment"
+    }
+    msg = "did not expect #{inspect record} to be found."
+
+    try do
+      refute_included(data(:payload), [data(:comment_3), data(:comment_1)])
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
+    end
+  end
 end

--- a/test/support/test_data.ex
+++ b/test/support/test_data.ex
@@ -13,6 +13,16 @@ defmodule JsonApiAssert.TestData do
     }
   end
 
+  def post_2 do
+    %{
+      "id" => "2",
+      "type" => "post",
+      "attributes" => %{
+        "title" => "Father of all demos"
+      }
+    }
+  end
+
   def author do
     %{
       "id" => "1",
@@ -20,6 +30,46 @@ defmodule JsonApiAssert.TestData do
       "attributes" => %{
         "first-name" => "Douglas",
         "last-name" => "Engelbart"
+      }
+    }
+  end
+
+  def comment_1 do
+    %{
+      "id" => "1",
+      "type" => "comment",
+      "attributes" => %{
+        "body" => "This is great!"
+      }
+    }
+  end
+
+  def comment_2 do
+    %{
+      "id" => "2",
+      "type" => "comment",
+      "attributes" => %{
+        "body" => "This is horrible!"
+      }
+    }
+  end
+
+  def comment_3 do
+    %{
+      "id" => "3",
+      "type" => "comment",
+      "attributes" => %{
+        "body" => "This is great!"
+      }
+    }
+  end
+
+  def comment_4 do
+    %{
+      "id" => "4",
+      "type" => "comment",
+      "attributes" => %{
+        "body" => "This is horrible!"
       }
     }
   end
@@ -82,6 +132,111 @@ defmodule JsonApiAssert.TestData do
           "relationships" => %{
             "post" => %{
               "data" => %{ "type" => "post", "id" => "1" }
+            }
+          }
+        }
+      ]
+    }
+  end
+
+  def payload_2 do
+    %{
+      "jsonapi" => %{
+        "version" => "1.0"
+      },
+      "data" => [%{
+        "id" => "1",
+        "type" => "post",
+        "attributes" => %{
+          "title" => "Mother of all demos"
+        },
+        "relationships" => %{
+          "author" => %{
+            "data" => %{ "type" => "author", "id" => "1" }
+          },
+          "comments" => %{
+            "data" => [
+              %{ "type" => "comment", "id" => "1" },
+              %{ "type" => "comment", "id" => "2" }
+            ]
+          }
+        }
+      }, %{
+        "id" => "2",
+        "type" => "post",
+        "attributes" => %{
+          "title" => "Father of all demos"
+        },
+        "relationships" => %{
+          "author" => %{
+            "data" => %{ "type" => "author", "id" => "1" }
+          },
+          "comments" => %{
+            "data" => [
+              %{ "type" => "comment", "id" => "3" },
+              %{ "type" => "comment", "id" => "4" }
+            ]
+          }
+        }
+      }],
+      "included" => [
+        %{
+          "id" => "1",
+          "type" => "author",
+          "attributes" => %{
+            "first-name" => "Douglas",
+            "last-name" => "Engelbart"
+          },
+          "relationships" => %{
+            "posts" => %{
+              "data" => [
+                %{ "type" => "post", "id" => "1" },
+                %{ "type" => "post", "id" => "2" }
+              ]
+            }
+          }
+        }, %{
+          "id" => "1",
+          "type" => "comment",
+          "attributes" => %{
+            "body" => "This is great!"
+          },
+          "relationships" => %{
+            "post" => %{
+              "data" => %{ "type" => "post", "id" => "1" }
+            }
+          }
+        }, %{
+          "id" => "2",
+          "type" => "comment",
+          "attributes" => %{
+            "body" => "This is horrible!"
+          },
+          "relationships" => %{
+            "post" => %{
+              "data" => %{ "type" => "post", "id" => "1" }
+            }
+          }
+        }, %{
+          "id" => "3",
+          "type" => "comment",
+          "attributes" => %{
+            "body" => "This is great!"
+          },
+          "relationships" => %{
+            "post" => %{
+              "data" => %{ "type" => "post", "id" => "2" }
+            }
+          }
+        }, %{
+          "id" => "4",
+          "type" => "comment",
+          "attributes" => %{
+            "body" => "This is horrible!"
+          },
+          "relationships" => %{
+            "post" => %{
+              "data" => %{ "type" => "post", "id" => "2" }
             }
           }
         }


### PR DESCRIPTION
`assert_data/2`, `refute_data/2`, `assert_included/2`, and
`refute_included/2` can now take lists. The lists will be iterated
through to assert/refute each record individually. This should cut down
on some test code LOCs
