### PR TITLE
Added more to _relationship functions

### DIFF
--- a/test/assert_relationship_test.exs
+++ b/test/assert_relationship_test.exs
@@ -104,4 +104,51 @@ defmodule AssertRelationshipTest do
     payload = assert_relationship(data(:payload), data(:author), as: "author", for: data(:post))
     assert payload == data(:payload)
   end
+
+  test "will assert the record is included when `included: true` is used" do
+    assert_relationship(data(:payload), data(:comment_1), as: "comments", for: data(:post), included: true)
+  end
+
+  test "will raise when  the record is not included and `included: true` is used" do
+    msg = "could not find a record with matching `id` 5 and `type` \"comment\""
+
+    try do
+      assert_relationship(data(:payload), data(:comment_5), as: "comments", for: data(:post), included: true)
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
+    end
+  end
+
+  test "will raise when the record is included and `included: false` is used" do
+    record = %{
+      "id" => "1",
+      "type" => "comment"
+    }
+    msg = "did not expect #{inspect record} to be found."
+
+    try do
+      assert_relationship(data(:payload), data(:comment_1), as: "comments", for: data(:post), included: false)
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
+    end
+  end
+
+  test "can assert many records at once" do
+    payload = assert_relationship(data(:payload_2), [data(:comment_1), data(:comment_2)], as: "comments", for: data(:post))
+
+    assert payload == data(:payload_2)
+  end
+
+  test "will fail if one of the records is not present" do
+    msg = "could not find relationship `comments` with `id` 3 and `type` \"comment\" for record matching `id` 1 and `type` \"post\""
+
+    try do
+      assert_relationship(data(:payload_2), [data(:comment_1), data(:comment_3)], as: "comments", for: data(:post))
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
+    end
+  end
 end

--- a/test/refute_relationship_test.exs
+++ b/test/refute_relationship_test.exs
@@ -86,4 +86,21 @@ defmodule RefuteRelationshipTest do
     payload = refute_relationship(data(:payload), data(:author), as: "writer", for: data(:post))
     assert payload == data(:payload)
   end
+
+  test "can refute many records at once" do
+    payload = refute_relationship(data(:payload_2), [data(:comment_3), data(:comment_4)], as: "comments", for: data(:post))
+
+    assert payload == data(:payload_2)
+  end
+
+  test "will fail if one of the records is present" do
+    msg = "was not expecting to find the relationship `comments` with `id` 1 and `type` \"comment\" for record matching `id` 1 and `type` \"post\""
+
+    try do
+      refute_relationship(data(:payload_2), [data(:comment_3), data(:comment_1)], as: "comments", for: data(:post))
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
+    end
+  end
 end

--- a/test/support/test_data.ex
+++ b/test/support/test_data.ex
@@ -74,6 +74,16 @@ defmodule JsonApiAssert.TestData do
     }
   end
 
+  def comment_5 do
+    %{
+      "id" => "5",
+      "type" => "comment",
+      "attributes" => %{
+        "body" => "This is OK"
+      }
+    }
+  end
+
   def payload do
     %{
       "jsonapi" => %{
@@ -92,7 +102,8 @@ defmodule JsonApiAssert.TestData do
           "comments" => %{
             "data" => [
               %{ "type" => "comment", "id" => "1" },
-              %{ "type" => "comment", "id" => "2" }
+              %{ "type" => "comment", "id" => "2" },
+              %{ "type" => "comment", "id" => "5" }
             ]
           }
         }


### PR DESCRIPTION
- `assert_relationship` can now take an optional `included` boolean to
  assert or refute if the record is included in the payload
- `assert_relationship` and `refute_relationship` can now take a list of
  child records
