### PR TITLE
Value matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,32 @@ schema](http://jsonapi.org/format/#document-resource-objects):
 }
 ```
 
+## Value matching via regex
+
+Use a Regex as the value if that value is non-deterministic.
+
+```elixir
+record = %{
+  "id" => ~r/\d+/,
+  "type" => "author",
+  "attributes" => %{
+    "first-name" => "Brian",
+    "last-name" => "Cardarella"
+  }
+}
+
+assert_data(payload, record)
+```
+
+A common use-case for this is when you are creating new records. The
+resulting value for the `id` is likely unknown and assigned at the
+run-time of the test suite. Using a Regex will allow you to assert that
+the id value is present and conforms to a value range and pattern that
+you expect.
+
+Be careful however, you may get false-positives as the Regex matching
+can be done upon data as well as datum sets.
+
 ## Authors
 
 * [Brian Cardarella](http://twitter.com/bcardarella)

--- a/test/assert_data_test.exs
+++ b/test/assert_data_test.exs
@@ -15,6 +15,14 @@ defmodule AssertDataTest do
     assert_data(data(:payload), data(:post))
   end
 
+  test "will not raise when record is found using regex" do
+    post =
+      data(:post)
+      |> put_in(["id"], ~r/\d+/)
+
+    assert_data(data(:payload), post)
+  end
+
   test "will raise when record with different attribute values is not found" do
     post =
       data(:post)
@@ -36,6 +44,21 @@ defmodule AssertDataTest do
     post =
       data(:post)
       |> put_in(["id"], "2")
+
+    try do
+      assert_data(data(:payload), post)
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
+    end
+  end
+
+  test "will raise when there is an id mismatch via regex" do
+    msg = "could not find a record with matching `id` ~r/^$/ and `type` \"post\""
+
+    post =
+      data(:post)
+      |> put_in(["id"], ~r/^$/)
 
     try do
       assert_data(data(:payload), post)

--- a/test/refute_data_test.exs
+++ b/test/refute_data_test.exs
@@ -27,6 +27,26 @@ defmodule RefuteDataTest do
     end
   end
 
+  test "will raise when record is found with regex" do
+    post =
+      data(:post)
+      |> put_in(["id"], ~r/\d+/)
+
+    record = %{
+      "id" => ~r/\d+/,
+      "type" => "post"
+    }
+
+    msg = "did not expect #{inspect record} to be found."
+
+    try do
+      refute_data(data(:payload), post)
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert msg == error.message
+    end
+  end
+
   test "will return the original payload" do
     post =
       data(:post)
@@ -41,6 +61,14 @@ defmodule RefuteDataTest do
     post =
       data(:post)
       |> put_in(["id"], "2")
+
+    refute_data(data(:payload), post)
+  end
+
+  test "will not raise if we force an id value mis-match with regex and everything else matches" do
+    post =
+      data(:post)
+      |> put_in(["id"], ~r/^$/)
 
     refute_data(data(:payload), post)
   end


### PR DESCRIPTION
Adds the ability to match on Regex in the payload. We can safely do
this as all values returned in JSON API spec are strings.

```elixir
record = %{
  "id" => ~r/\d+/,
  "type" => "author",
  "attributes" => %{
    "first-name" => "Brian",
    "last-name" => "Cardarella"
  }
}

assert_data(payload, record)
```

A common use-case for this is when you are creating new records. The resulting value for the `id` is likely unknown and assigned at the run-time of the test suite. Using a Regex will allow you to assert that the id value is present and conforms to a value range and pattern that you expect.

This can be used on any value within the payload, but my current need is for record creation and `id` matching.