### PR TITLE
Naive date time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: elixir
 elixir:
-  - 1.2.0
+  - 1.3.0
 otp_release:
   - 18.0
 sudo: false # to use faster container based build environment

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: elixir
 elixir:
   - 1.3.0
+  - 1.4.0
 otp_release:
   - 18.0
 sudo: false # to use faster container based build environment

--- a/lib/json_api_assert/serializer.ex
+++ b/lib/json_api_assert/serializer.ex
@@ -58,7 +58,7 @@ defmodule JsonApiAssert.Serializer do
       struct
       |> Module.split()
       |> List.last()
-      |> Mix.Utils.underscore()
+      |> Macro.underscore()
 
     Map.put(map, "type", type)
   end

--- a/lib/json_api_assert/serializer.ex
+++ b/lib/json_api_assert/serializer.ex
@@ -119,5 +119,7 @@ defmodule JsonApiAssert.Serializer do
     do: apply(Ecto.Time, :to_iso8601, [value])
   defp serialize_value(%{__struct__: Ecto.Date} = value),
     do: apply(Ecto.Date, :to_iso8601, [value])
+  defp serialize_value(%{__struct__: NaiveDateTime} = value),
+    do: apply(NaiveDateTime, :to_iso8601, [value])
   defp serialize_value(value), do: value
 end

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule JsonApiAssert.Mixfile do
      start_permanent: Mix.env == :prod,
      package: package(),
      description: "assertions for JSON API payload",
-     deps: deps,
+     deps: deps(),
      docs: [
       main: "JsonApiAssert",
       logo: "jsonapi-assert.png"

--- a/test/serializer_test.exs
+++ b/test/serializer_test.exs
@@ -249,4 +249,21 @@ defmodule JsonApiAssert.SerializerTest do
 
     assert actual == expected
   end
+
+  test "serializing NaiveDateTime values" do
+    {:ok, created_at} = NaiveDateTime.from_erl({{2016,1,1},{0,0,0}})
+    actual =
+      %Post{id: 1, created_at: created_at}
+      |> serialize()
+
+    expected = %{
+      "id" => "1",
+      "type" => "post",
+      "attributes" => %{
+        "created-at" => "2016-01-01T00:00:00"
+      }
+    }
+
+    assert actual == expected
+  end
 end


### PR DESCRIPTION
## Changes proposed in this pull request

Add NaiveDateTime serialization.
Ecto 2.1 returns NaiveDateTime structs for inserted_at and updated_at values, which breaks comparison with json_api_assert serialized records.

**This requires NaiveDateTime and breaks compat with pre-1.3 elixir.**
