### PR TITLE
remove now private add_doc in elixir 1.6

### DIFF
--- a/lib/json_api_assert/inflector.ex
+++ b/lib/json_api_assert/inflector.ex
@@ -24,27 +24,25 @@ defmodule JsonApiAssert.Inflector do
                |> Map.put(plural, singular)
              end)
 
+      @doc """
+      Pluralize the given word
+
+      Will try to use a pre-defined rule or default to appending "s" to the end of the word.
+      """
       def pluralize(word) when is_binary(word) do
         @rules
         |> Map.get(word, "#{word}s")
       end
 
+      @doc """
+      Singularize the given word
+
+      Will try to use a pre-defined rule or default to removing the "s" at the end of the word.
+      """
       def singularize(word) when is_binary(word) do
         @rules
         |> Map.get(word, String.replace(word, ~r/s$/, ""))
       end
     end
   end
-
-  Module.add_doc __MODULE__, __ENV__.line + 1, :def, {:pluralize, 1}, (quote do: [word]), """
-  Pluralize the given word
-
-  Will try to use a pre-defined rule or default to appending "s" to the end of the word.
-  """
-
-  Module.add_doc __MODULE__, __ENV__.line + 1, :def, {:singularize, 1}, (quote do: [word]), """
-  Singuliarze the given word
-
-  Will try to use a pre-defined rule or default to removing the "s" at the end of the word.
-  """
 end


### PR DESCRIPTION
## Changes proposed in this pull request

Looks like 1.6, `Module.add_doc` is now [private](https://github.com/elixir-lang/elixir/blob/master/lib/elixir/lib/module.ex#L1223).

Since there is no other alternative, I'm guessing `@doc` will work in a macro.  No luck in the iex terminal though to verify.